### PR TITLE
日報機能と、コメント機能の追加

### DIFF
--- a/app/assets/stylesheets/comments.css
+++ b/app/assets/stylesheets/comments.css
@@ -1,0 +1,38 @@
+.comments-container {
+    width: 100%;
+    margin-top: 20px;
+    font-size: 16px;
+  }
+  
+  .comments-list {
+    list-style: none;
+    padding: 0;
+  }
+  
+  .comment-item {
+    margin: 10px 0;
+    padding: 10px;
+    border: 1px solid #ddd;
+    background-color: #f9f9f9;
+  }
+  
+  .comment-author {
+    font-size: 14px;
+    color: #777;
+  }
+  
+  .edit-link,
+  .delete-link {
+    color: #007bff;
+    text-decoration: none;
+  }
+  
+  .edit-link:hover,
+  .delete-link:hover {
+    text-decoration: underline;
+  }
+  
+  .no-comments {
+    color: #999;
+    font-style: italic;
+  }

--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -1,0 +1,14 @@
+class Books::CommentsController < CommentsController
+  before_action :set_commentable
+
+  private
+
+  def set_commentable
+    @commentable = Book.find(params[:book_id])
+  end
+
+  def render_commentable_show
+    @book = @commentable
+    render 'books/show'
+  end
+end

--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -1,3 +1,5 @@
+# Frozen_string_literal: true
+
 class Books::CommentsController < CommentsController
   before_action :set_commentable
 

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -9,7 +9,10 @@ class BooksController < ApplicationController
   end
 
   # GET /books/1 or /books/1.json
-  def show; end
+  def show
+    @comment = Comment.new
+    @comments = @book.comments
+  end
 
   # GET /books/new
   def new

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,9 +1,11 @@
+# Frozen_string_literal: true
+
 class CommentsController < ApplicationController
-  before_action :set_comment, only: %i[edit update destroy]
-  before_action :ensure_correct_user, only: %i[edit update destroy]
+  before_action :set_comment, only: %i[edit destroy]
+  before_action :ensure_correct_user, only: %i[edit destroy]
 
   def edit; end
-  
+
   def create
     @comment = @commentable.comments.build(comment_params)
     @comment.user = current_user
@@ -14,26 +16,24 @@ class CommentsController < ApplicationController
       render_commentable_show
     end
   end
-    
-    def destroy
-      @comment.destroy
-      redirect_to @commentable, notice: t('controllers.common.notice_destroy', name: Comment.model_name.human)
-    end
-  
-    private
-  
-    def set_comment
-      @comment = Comment.find(params[:id])
-      @commentable = @comment.commentable
-    end
+
+  def destroy
+    @comment.destroy
+    redirect_to @commentable, notice: t('controllers.common.notice_destroy', name: Comment.model_name.human)
+  end
+
+  private
+
+  def set_comment
+    @comment = Comment.find(params[:id])
+    @commentable = @comment.commentable
+  end
 
   def comment_params
     params.require(:comment).permit(:content)
   end
 
   def ensure_correct_user
-    unless @comment.user == current_user
-      redirect_to reports_path, notice: "You are not authorized to edit this report."
-    end
+    redirect_to reports_path, notice: 'You are not authorized to edit this report.' unless @comment.user == current_user
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,39 @@
+class CommentsController < ApplicationController
+  before_action :set_comment, only: %i[edit update destroy]
+  before_action :ensure_correct_user, only: %i[edit update destroy]
+
+  def edit; end
+  
+  def create
+    @comment = @commentable.comments.build(comment_params)
+    @comment.user = current_user
+    if @comment.save
+      redirect_to @commentable, notice: t('controllers.common.notice_create', name: Comment.model_name.human)
+    else
+      @comments = @commentable.comments
+      render_commentable_show
+    end
+  end
+    
+    def destroy
+      @comment.destroy
+      redirect_to @commentable, notice: t('controllers.common.notice_destroy', name: Comment.model_name.human)
+    end
+  
+    private
+  
+    def set_comment
+      @comment = Comment.find(params[:id])
+      @commentable = @comment.commentable
+    end
+
+  def comment_params
+    params.require(:comment).permit(:content)
+  end
+
+  def ensure_correct_user
+    unless @comment.user == current_user
+      redirect_to reports_path, notice: "You are not authorized to edit this report."
+    end
+  end
+end

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -1,0 +1,14 @@
+class Reports::CommentsController < CommentsController
+  before_action :set_commentable
+  
+  private
+  
+  def set_commentable
+    @commentable = Report.find(params[:report_id])
+  end
+
+  def render_commentable_show
+    @report = @commentable
+    render 'reports/show'
+  end
+end

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -1,8 +1,10 @@
+# Frozen_string_literal: true
+
 class Reports::CommentsController < CommentsController
   before_action :set_commentable
-  
+
   private
-  
+
   def set_commentable
     @commentable = Report.find(params[:report_id])
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,7 +1,8 @@
-class ReportsController < ApplicationController
-  before_action :set_report, only: %i[ show edit update destroy ]
-  before_action :ensure_correct_user, only: %i[edit update destroy]
+# Frozen_string_literal: true
 
+class ReportsController < ApplicationController
+  before_action :set_report, only: %i[show edit update destroy]
+  before_action :ensure_correct_user, only: %i[edit update destroy]
 
   # GET /reports or /reports.json
   def index
@@ -20,16 +21,15 @@ class ReportsController < ApplicationController
   end
 
   # GET /reports/1/edit
-  def edit
-  end
+  def edit; end
 
   # POST /reports or /reports.json
   def create
     @report = current_user.reports.new(report_params)
-  
+
     respond_to do |format|
       if @report.save
-        format.html { redirect_to report_url(@report), notice: "Report was successfully created." }
+        format.html { redirect_to report_url(@report), notice: 'Report was successfully created.' }
         format.json { render :show, status: :created, location: @report }
       else
         format.html { render :new, status: :unprocessable_entity }
@@ -42,7 +42,7 @@ class ReportsController < ApplicationController
   def update
     respond_to do |format|
       if @report.update(report_params)
-        format.html { redirect_to report_url(@report), notice: "Report was successfully updated." }
+        format.html { redirect_to report_url(@report), notice: 'Report was successfully updated.' }
         format.json { render :show, status: :ok, location: @report }
       else
         format.html { render :edit, status: :unprocessable_entity }
@@ -56,25 +56,22 @@ class ReportsController < ApplicationController
     @report.destroy
 
     respond_to do |format|
-      format.html { redirect_to reports_url, notice: "Report was successfully destroyed." }
+      format.html { redirect_to reports_url, notice: 'Report was successfully destroyed.' }
       format.json { head :no_content }
     end
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_report
-      @report = Report.find(params[:id])
-    end
 
-    # Only allow a list of trusted parameters through.
-    def report_params
-      params.require(:report).permit(:title, :body)
-    end
+  def set_report
+    @report = Report.find(params[:id])
+  end
 
-    def ensure_correct_user
-      unless @report.user == current_user
-        redirect_to reports_path, notice: "You are not authorized to edit this report."
-      end
-    end
+  def report_params
+    params.require(:report).permit(:title, :body)
+  end
+
+  def ensure_correct_user
+    redirect_to reports_path, notice: 'You are not authorized to edit this report.' unless @report.user == current_user
+  end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,70 @@
+class ReportsController < ApplicationController
+  before_action :set_report, only: %i[ show edit update destroy ]
+
+  # GET /reports or /reports.json
+  def index
+    @reports = Report.order(:id).page(params[:page])
+  end
+
+  # GET /reports/1 or /reports/1.json
+  def show
+  end
+
+  # GET /reports/new
+  def new
+    @report = Report.new
+  end
+
+  # GET /reports/1/edit
+  def edit
+  end
+
+  # POST /reports or /reports.json
+  def create
+    @report = Report.new(report_params)
+
+    respond_to do |format|
+      if @report.save
+        format.html { redirect_to report_url(@report), notice: "Report was successfully created." }
+        format.json { render :show, status: :created, location: @report }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @report.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /reports/1 or /reports/1.json
+  def update
+    respond_to do |format|
+      if @report.update(report_params)
+        format.html { redirect_to report_url(@report), notice: "Report was successfully updated." }
+        format.json { render :show, status: :ok, location: @report }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @report.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /reports/1 or /reports/1.json
+  def destroy
+    @report.destroy
+
+    respond_to do |format|
+      format.html { redirect_to reports_url, notice: "Report was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_report
+      @report = Report.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def report_params
+      params.require(:report).permit(:title, :body)
+    end
+end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,5 +1,7 @@
 class ReportsController < ApplicationController
   before_action :set_report, only: %i[ show edit update destroy ]
+  before_action :ensure_correct_user, only: %i[edit update destroy]
+
 
   # GET /reports or /reports.json
   def index
@@ -21,8 +23,8 @@ class ReportsController < ApplicationController
 
   # POST /reports or /reports.json
   def create
-    @report = Report.new(report_params)
-
+    @report = current_user.reports.new(report_params)
+  
     respond_to do |format|
       if @report.save
         format.html { redirect_to report_url(@report), notice: "Report was successfully created." }
@@ -66,5 +68,11 @@ class ReportsController < ApplicationController
     # Only allow a list of trusted parameters through.
     def report_params
       params.require(:report).permit(:title, :body)
+    end
+
+    def ensure_correct_user
+      unless @report.user == current_user
+        redirect_to reports_path, notice: "You are not authorized to edit this report."
+      end
     end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -10,6 +10,8 @@ class ReportsController < ApplicationController
 
   # GET /reports/1 or /reports/1.json
   def show
+    @comment = Comment.new
+    @comments = @report.comments
   end
 
   # GET /reports/new

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,4 +2,5 @@
 
 class Book < ApplicationRecord
   mount_uploader :picture, PictureUploader
+  has_many :comments, as: :commentable, dependent: :destroy
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,6 +1,8 @@
+# Frozen_string_literal: true
+
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :commentable, polymorphic: true
 
-  validates :content, presence: true 
+  validates :content, presence: true
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,6 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :commentable, polymorphic: true
+
+  validates :content, presence: true 
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,0 +1,2 @@
+class Report < ApplicationRecord
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,2 +1,3 @@
 class Report < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,3 +1,4 @@
 class Report < ApplicationRecord
   belongs_to :user
+  has_many :comments, as: :commentable, dependent: :destroy
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,3 +1,5 @@
+# Frozen_string_literal: true
+
 class Report < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
   has_one_attached :avatar do |attachable|
     attachable.variant :thumb, resize_to_limit: [150, 150]
   end
+  has_many :reports, dependent: :destroy
 end

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -10,3 +10,6 @@
 
   <%= button_to t('views.common.destroy', name: Book.model_name.human.downcase), @book, method: :delete %>
 </nav>
+
+<%= render 'comments/comments', commentable: @book, comments: @comments %>
+<%= render 'comments/form', commentable: @book, comment: @comment %>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -1,0 +1,23 @@
+<div class="comments-container">
+  <strong><%= Comment.model_name.human %>:</strong>
+  <% if comments.any? %>
+    <ul class="comments-list">
+      <% comments.each do |comment| %>
+        <% if comment.persisted? %>
+          <div class="comment-item">
+            <%= comment.content %>
+            <div class="comment-author">
+              <%= comment.user.name.present? ? comment.user.name : comment.user.email %> 
+              <%= comment.created_at %>
+            </div>
+            <% if comment.user == current_user %>
+              <%= button_to t('activerecord.comments.form.delete'), [comment], method: :delete %>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+    </ul>
+  <% else %>
+    <p class="no-comments"><%= t('activerecord.comments.form.no_comments') %></p>
+  <% end %>
+</div>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -7,7 +7,7 @@
           <div class="comment-item">
             <%= comment.content %>
             <div class="comment-author">
-              <%= comment.user.name.present? ? comment.user.name : comment.user.email %> 
+              <%= comment.user.name.present? ? comment.user.name : comment.user.email %>
               <%= comment.created_at %>
             </div>
             <% if comment.user == current_user %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,4 @@
+<%= form_with model: [commentable, comment] do |f| %>
+  <%= f.text_field :content, required: true %>
+  <%= f.submit %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,9 @@
           <li>
             <%= link_to User.model_name.human, users_path %>
           </li>
+           <li>
+            <%= link_to Report.model_name.human, reports_path %>
+          </li>
         </ul>
         <div class="title">
           <%# html_safeを使っているが、XSSは発生しないのを確認済み %>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: report) do |form| %>
+  <% if report.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(report.errors.count, "error") %> prohibited this report from being saved:</h2>
+
+      <ul>
+        <% report.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :title, style: "display: block" %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div>
+    <%= form.label :body, style: "display: block" %>
+    <%= form.text_area :body %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/reports/_report.html.erb
+++ b/app/views/reports/_report.html.erb
@@ -1,0 +1,12 @@
+<div id="<%= dom_id report %>">
+  <p>
+    <strong><%= Report.human_attribute_name(:title) %>:</strong>
+    <%= report.title %>
+  </p>
+
+  <p>
+    <strong><%= Report.human_attribute_name(:body) %>:</strong>
+    <%= report.body %>
+  </p>
+
+</div>

--- a/app/views/reports/_report.html.erb
+++ b/app/views/reports/_report.html.erb
@@ -1,4 +1,15 @@
 <div id="<%= dom_id report %>">
+
+  <p>
+    <strong><%= Report.human_attribute_name(:created_at) %>:</strong>
+    <%= report.created_at %>
+  </p>
+
+  <p>
+    <strong><%= Report.human_attribute_name(:user) %>:</strong>
+    <%= report.user.name.present? ? report.user.name : report.user.email %>
+  </p>
+
   <p>
     <strong><%= Report.human_attribute_name(:title) %>:</strong>
     <%= report.title %>

--- a/app/views/reports/edit.html.erb
+++ b/app/views/reports/edit.html.erb
@@ -1,0 +1,10 @@
+<h1><%= t('views.common.title_edit', name: Report.model_name.human.downcase) %></h1>
+
+<%= render "form", report: @report %>
+
+<br>
+
+<nav class="page-nav">
+  <%= link_to t('views.common.show', name: Report.model_name.human.downcase), @report %> |
+  <%= link_to t('views.common.back', name: i18n_pluralize(Report.model_name.human.downcase)), reports_path %>
+</nav>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -17,5 +17,5 @@
 <%= paginate @reports %>
 
 <nav class="page-nav">
-    <%= link_to t('views.common.new', name: Report.model_name.human.downcase), new_book_path %>
+    <%= link_to t('views.common.new', name: Report.model_name.human.downcase), new_report_path %>
 </nav>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,0 +1,21 @@
+<p style="color: green"><%= notice %></p>
+
+<h1><%= t('views.common.title_index', name: i18n_pluralize(Report.model_name.human)) %></h1>
+
+<div id="reports" class="index-items">
+    <% @reports.each do |report| %>
+    <div class="index-item">
+      <%= render report %>
+      <p>
+        <%= link_to t('views.common.show', name:Report.model_name.human.downcase), report %>
+      </p>
+    </div>
+    <% end %>
+</div>
+
+
+<%= paginate @reports %>
+
+<nav class="page-nav">
+    <%= link_to t('views.common.new', name: Report.model_name.human.downcase), new_book_path %>
+</nav>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -13,7 +13,6 @@
     <% end %>
 </div>
 
-
 <%= paginate @reports %>
 
 <nav class="page-nav">

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,0 +1,9 @@
+<h1><%= t('views.common.title_new', name: Report.model_name.human.downcase) %></h1>
+
+<%= render "form", report: @report %>
+
+<br>
+
+<nav class="page-nav">
+  <%= link_to t('views.common.back', name: i18n_pluralize(Report.model_name.human.downcase)), reports_path %>
+</nav>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,0 +1,12 @@
+<h1><%= t('views.common.title_show', name: Report.model_name.human) %></h1>
+
+<div class="show-item">
+  <%= render @report %>
+</div>
+
+<nav class="page-nav">
+  <%= link_to t('views.common.edit', name: Report.model_name.human.downcase), edit_report_path(@report) %> |
+  <%= link_to t('views.common.back', name: i18n_pluralize(Report.model_name.human.downcase)), reports_path %>
+
+  <%= button_to t('views.common.destroy', name: Report.model_name.human.downcase), @report, method: :delete %>
+</nav>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -5,8 +5,12 @@
 </div>
 
 <nav class="page-nav">
-  <%= link_to t('views.common.edit', name: Report.model_name.human.downcase), edit_report_path(@report) %> |
+  <% if current_user == @report.user %>
+    <%= link_to t('views.common.edit', name: Report.model_name.human.downcase), edit_report_path(@report) %> |
+  <% end %>
   <%= link_to t('views.common.back', name: i18n_pluralize(Report.model_name.human.downcase)), reports_path %>
 
-  <%= button_to t('views.common.destroy', name: Report.model_name.human.downcase), @report, method: :delete %>
+  <% if current_user == @report.user %>
+    <%= button_to t('views.common.destroy', name: Report.model_name.human.downcase), @report, method: :delete %>
+  <% end %>
 </nav>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -14,3 +14,6 @@
     <%= button_to t('views.common.destroy', name: Report.model_name.human.downcase), @report, method: :delete %>
   <% end %>
 </nav>
+
+<%= render 'comments/comments', commentable: @report, comments: @comments %>
+<%= render 'comments/form', commentable: @report, comment: @comment %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ module BooksApp
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Tokyo'
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       book: 本
       user: ユーザ
+      report: 日報
 
     attributes:
       book:
@@ -16,3 +17,7 @@ ja:
         address: 住所
         self_introduction: 自己紹介文
         avatar: ユーザ画像
+      report:
+        title: タイトル
+        body: 内容
+        created_at: 作成日時

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -4,6 +4,7 @@ ja:
       book: 本
       user: ユーザ
       report: 日報
+      comment: コメント
 
     attributes:
       book:
@@ -21,3 +22,8 @@ ja:
         title: タイトル
         body: 内容
         created_at: 作成日時
+    comments:
+      form:
+        create: コメントする
+        no_comments: コメントはまだありません
+        delete: 削除

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,11 @@ Rails.application.routes.draw do
   resources :books
   resources :users, only: %i(index show)
   resources :reports
+  resources :comments, only: :destroy
+  resources :books do
+    resources :comments, only: :create, module: :books
+  end
+  resources :reports do
+    resources :comments, only: :create, module: :reports
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
+  resources :reports
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   devise_for :users
   root to: 'books#index'
   resources :books
   resources :users, only: %i(index show)
+  resources :reports
 end

--- a/db/migrate/20230805123643_create_reports.rb
+++ b/db/migrate/20230805123643_create_reports.rb
@@ -1,0 +1,10 @@
+class CreateReports < ActiveRecord::Migration[7.0]
+  def change
+    create_table :reports do |t|
+      t.string :title
+      t.text :body
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230806042023_add_user_to_reports.rb
+++ b/db/migrate/20230806042023_add_user_to_reports.rb
@@ -1,0 +1,6 @@
+class AddUserToReports < ActiveRecord::Migration[7.0]
+  def change
+    Report.delete_all
+    add_reference :reports, :user, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20230806064241_create_comments.rb
+++ b/db/migrate/20230806064241_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :comments do |t|
+      t.references :user, null: false, foreign_key: true
+      t.text :content
+      t.references :commentable, polymorphic: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_02_070626) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_05_123643) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_070626) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
+    t.integer "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -46,6 +46,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_070626) do
     t.datetime "updated_at", null: false
     t.string "author"
     t.string "picture"
+  end
+
+  create_table "reports", force: :cascade do |t|
+    t.string "title"
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_05_123643) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_06_042023) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -53,6 +53,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_05_123643) do
     t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["user_id"], name: "index_reports_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -73,4 +75,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_05_123643) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "reports", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_06_042023) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_06_064241) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -48,6 +48,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_06_042023) do
     t.string "picture"
   end
 
+  create_table "comments", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.text "content"
+    t.string "commentable_type", null: false
+    t.integer "commentable_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
   create_table "reports", force: :cascade do |t|
     t.string "title"
     t.text "body"
@@ -75,5 +86,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_06_042023) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "users"
   add_foreign_key "reports", "users"
 end

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class ReportsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @report = reports(:one)
+  end
+
+  test "should get index" do
+    get reports_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_report_url
+    assert_response :success
+  end
+
+  test "should create report" do
+    assert_difference("Report.count") do
+      post reports_url, params: { report: { body: @report.body, title: @report.title } }
+    end
+
+    assert_redirected_to report_url(Report.last)
+  end
+
+  test "should show report" do
+    get report_url(@report)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_report_url(@report)
+    assert_response :success
+  end
+
+  test "should update report" do
+    patch report_url(@report), params: { report: { body: @report.body, title: @report.title } }
+    assert_redirected_to report_url(@report)
+  end
+
+  test "should destroy report" do
+    assert_difference("Report.count", -1) do
+      delete report_url(@report)
+    end
+
+    assert_redirected_to reports_url
+  end
+end

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -1,45 +1,47 @@
-require "test_helper"
+# Frozen_string_literal: true
+
+require 'test_helper'
 
 class ReportsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @report = reports(:one)
   end
 
-  test "should get index" do
+  test 'should get index' do
     get reports_url
     assert_response :success
   end
 
-  test "should get new" do
+  test 'should get new' do
     get new_report_url
     assert_response :success
   end
 
-  test "should create report" do
-    assert_difference("Report.count") do
+  test 'should create report' do
+    assert_difference('Report.count') do
       post reports_url, params: { report: { body: @report.body, title: @report.title } }
     end
 
     assert_redirected_to report_url(Report.last)
   end
 
-  test "should show report" do
+  test 'should show report' do
     get report_url(@report)
     assert_response :success
   end
 
-  test "should get edit" do
+  test 'should get edit' do
     get edit_report_url(@report)
     assert_response :success
   end
 
-  test "should update report" do
+  test 'should update report' do
     patch report_url(@report), params: { report: { body: @report.body, title: @report.title } }
     assert_redirected_to report_url(@report)
   end
 
-  test "should destroy report" do
-    assert_difference("Report.count", -1) do
+  test 'should destroy report' do
+    assert_difference('Report.count', -1) do
       delete report_url(@report)
     end
 

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  content: MyText
+  commentable: one
+  commentable_type: Commentable
+
+two:
+  user: two
+  content: MyText
+  commentable: two
+  commentable_type: Commentable

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  body: MyText
+
+two:
+  title: MyString
+  body: MyText


### PR DESCRIPTION
## やったこと

- [x] 本（books）のCRUDを作ったときの復習として日報（reports）が投稿できるようにする（reportsのCRUDを作る。入力項目はタイトルと本文だけで良い。created_atの日付を日報の投稿日とする）
- [x] 日報を更新・削除できるのはその日報を投稿した本人のみ（本のCRUDは特に制限なし）
- [x] 本と日報の各詳細画面からコメントを投稿できるようにする。
- [x] コメントを削除できるのはそのコメントを投稿した本人のみ
- [x] 投稿したコメントは本と日報の各詳細画面から確認できる。投稿した内容に加えて、投稿したユーザーの名前（未入力ならメアド）と投稿日時も表示する
- [x] 本と日報の各詳細画面でコメントが投稿できている様子をスクショする
- [x] rubocopとerblintをパスさせる（要スクリーンショット）

## みてほしいところ
- かなりファイル数が多くなってしまった。一つの課題でもプリクエストを分けるべきだったかどうか伺いたいです。
- コードの作法
- 仕様の認識があっているかどうか

## 参考・スクリーンショット
- 本の詳細でコメントができる
  - <img width="1017" alt="スクリーンショット 2023-08-06 21 19 51" src="https://github.com/NoritakaIkeda/fjord-books_app-2023/assets/50833174/64fdad85-f545-4948-a054-cbfdbb3d96ce">
- 日報の詳細でコメントができる
  - <img width="1011" alt="スクリーンショット 2023-08-06 21 20 02" src="https://github.com/NoritakaIkeda/fjord-books_app-2023/assets/50833174/7ea6ae46-536e-4a6f-9a6b-4d01d6c44e63">
- コメントがないと、その旨が表示される
  - <img width="672" alt="スクリーンショット 2023-08-06 20 33 00" src="https://github.com/NoritakaIkeda/fjord-books_app-2023/assets/50833174/42441dec-e841-4e25-87a6-5d0c004e47e4">
- rubocopとlintがパスした様子
  - <img width="653" alt="スクリーンショット 2023-08-06 21 09 55" src="https://github.com/NoritakaIkeda/fjord-books_app-2023/assets/50833174/f82fc12e-7591-4a71-9e47-bf95d456b4e5">
